### PR TITLE
Agregue la rotacion opcional con CV2

### DIFF
--- a/annotations/generate_annotations_pascal2012.py
+++ b/annotations/generate_annotations_pascal2012.py
@@ -9,11 +9,15 @@ from annotations.classes.queryimage import QueryImage
 
 VIDEO_EXTENSION = ['.mov', '.avi', '.mpeg', '.mp4']
 VIDEO_ROTATE = 0
+<<<<<<< HEAD
 VIDEO_STEP = 45
 # EXAMPLE GRAY "cv2.COLOR_BGR2GRAY"
 # EXAMPLE HSV "cv2.COLOR_BGR2HSV"
 # EXAMPLE RGB ""
 COLOR = "cv2.COLOR_BGR2HSV"
+=======
+VIDEO_STEP = 60
+>>>>>>> Agregue la rotacion opcional con CV2
 
 PATH_IN_IMAGES = "D:/proyecto/usher-rec/annotations/IN/"
 PATH_OUT_IMAGES = "D:/proyecto/usher-rec/annotations/OUT/"
@@ -60,10 +64,10 @@ def open_videos_frames(path_in, path_out, filetype_list, rotate):
                         if not ret:
                             break
                         if rotate:
-                            frame = cv2.transpose(frame, frame)
-                            frame = cv2.flip(frame, 1)
-                        if not COLOR is "":
-                            frame = cv2.cvtColor(frame, COLOR)
+                            (x,y) = (video.get_width()/2, video.get_height()/2)
+                            M = cv2.getRotationMatrix2D((x,y) , 180, 1.0)
+                            frame = cv2.warpAffine(frame, M, (video.get_width(), video.get_height()))
+                            # frame = cv2.flip(frame, 1)
                         frame_name = JPG_VOC2012_OUT + video.basename + '_' + str('{0:0{width}}'.format(count_frame, width=10)) + '.jpg'
                         cv2.imwrite(frame_name, frame)
                         print("Create frame : " + os.path.splitext(os.path.basename(frame_name))[0])


### PR DESCRIPTION
# Resumen
- Agregue al script base que genera anotaciones la posibilidad de rotar las imágenes que se obtienen de video utilizando la misma libreria OpenCV